### PR TITLE
Replacing the hard-coded IDs for difficulties with a more modular way of doing it.

### DIFF
--- a/src/api/controllers/user.controller.js
+++ b/src/api/controllers/user.controller.js
@@ -6,6 +6,8 @@ const log = require("npmlog");
 const {levelDiff} = require("../../modules/XPHandler");
 const Task = require("../../models/task.model");
 
+const difficultyConfig = require("../../config/difficulty.config");
+
 class UserController {
   async deleteUser(req,res) {
     console.log("POST /users/deleteUser"); 
@@ -166,49 +168,18 @@ class UserController {
       res.status(400).json({response: "error", error: "User already exists"});
       return;
     }
-    let completed = [];
-    let inprogress = [];
-    const items = ["62c382d46cac02c487e243cb",
-      "62c383846cac02c487e243cc"
-    ];
-    if (req.body.difficulty === "medium") {
-      completed = [
-        "62c226cf9efefadfd10e20ad", //med 1
-        "62c226d09efefadfd10e20bd", //fit 1
-        "62c226cf9efefadfd10e20b2", //jour 1
-      ];
-      inprogress = [
-        "62c226d19efefadfd10e20d9", //fit 2
-        "62c226d09efefadfd10e20b6", //med 2
-        "62c226d89efefadfd10e21a0" //jour 2
-      ];
-      items.push("62c226d09efefadfd10e20c6"); //how to start meditating
-      items.push("62c226d09efefadfd10e20c6"); // strong
-      items.push("62c226e29efefadfd10e2292"); // exercise guide
+
+    const difficulty = await difficultyConfig;
+
+    // Extract the data from the chosen difficulty
+    if (!await difficulty[req.body.difficulty.toLowerCase()]) {
+      console.log(`Invalid difficulty ${req.body.difficulty}`)
+      res.status(400).json({response: "error", error: `Invalid difficulty ${req.body.difficulty}`});
+      return;
     }
-    if (req.body.difficulty === "hard") {
-      completed = [
-        "62c226cf9efefadfd10e20ad",//med 1
-        "62c226d09efefadfd10e20bd",//fit 1
-        "62c226cf9efefadfd10e20b2",//jour 1
-        "62c226d09efefadfd10e20b6",//med 2
-        "62c226d89efefadfd10e21a0",//jour 2
-        "62c226d19efefadfd10e20d9",//fit 2
-        "62c226d89efefadfd10e2197", //rel 1
-      ];
-      inprogress = [
-        "62c226d19efefadfd10e20e2",//fit 3
-        "62c226d09efefadfd10e20c0", //med 3
-        "62c226d89efefadfd10e21a3", // read 1
-        "62c226dd9efefadfd10e221d", // jour 3
-        "62c226d89efefadfd10e21a6" // rel 2
-      ];
-      items.push("62c226d09efefadfd10e20c6"); //how to start meditating
-      items.push("62c226d09efefadfd10e20c6"); // strong
-      items.push("62c226e29efefadfd10e2292"); // exercise guide
-      items.push("62c226dd9efefadfd10e2220"); //advanced journal
-      items.push("62c226dd9efefadfd10e2222"); // how to show gratitude
-    }
+    const completed = await difficulty[req.body.difficulty.toLowerCase()].completed || [];
+    const inprogress = await difficulty[req.body.difficulty.toLowerCase()].inprogress || [];
+    const items = await difficulty[req.body.difficulty.toLowerCase()].items || [];
 
     const user = await User.create({
       discordid: req.body.discordid,

--- a/src/config/difficulty.config.js
+++ b/src/config/difficulty.config.js
@@ -1,0 +1,133 @@
+// Config for the difficuties chosen during setup.
+
+// Inherit option means that each difficulty will inherit from the one above it.
+// The first difficulty is always the easiest and will not inherit from anything.
+// The last difficulty is always the hardest and will inherit from everything.
+
+// The default field is the one that everything will inherit from regardless if inherit is set to true or false.
+
+const Item = require("../models/item.model");
+const Skill = require("../models/skill.model");
+
+const config = {
+  "inherit": true,
+  "default": {
+    "items": [
+      "SELF IMPROVEMENT GUIDE BOOK",
+      "RUSTY DAGGER"
+    ]
+  },
+  "difficulties": {
+    "easy": {},
+    "medium": {
+      "completed": [
+        "MEDITATION 1",
+        "FITNESS 1",
+        "JOURNALING 1"
+      ],
+      "inprogress": [
+        "FITNESS 2",
+        "MEDITATION 2",
+        "JOURNALING 2"
+      ],
+      "items": [
+        "STRONG APP",
+        "HOW TO START MEDITATING",
+        "MYFITNESSPAL"
+      ]
+    },
+    "hard": {
+      "completed": [
+        "MEDITATION 2",
+        "FITNESS 2",
+        "JOURNALING 2",
+        "RELATIONSHIPS 1"
+      ],
+      "inprogress": [
+        "FITNESS 3",
+        "MEDITATION 3",
+        "JOURNALING 3",
+        "RELATIONSHIPS 2",
+        "READING 1"
+      ],
+      "items": [
+        "ADVANCED JOURNAL"
+      ]
+    }
+  }
+};
+
+async function createConfig() {
+  const newConfig = {};
+  // Convert the config to a constant JSON that can be used in the code.
+  if (config.inherit) {
+    let lastDifficulty = config.default;
+    for (const difficulty in config.difficulties) {
+      const keys = new Set(Object.keys(config.difficulties[difficulty]).concat(Object.keys(lastDifficulty)));
+      newConfig[difficulty] = {};
+      for (const key of keys) {
+        newConfig[difficulty][key] = (config.difficulties[difficulty][key] || []).concat(lastDifficulty[key] || []);
+      }
+      lastDifficulty = newConfig[difficulty];
+    }
+  }
+  else {
+    for (const difficulty in config.difficulties) {
+      for (const field in config.default) {
+        newConfig[difficulty] = config.difficulties[difficulty];
+        newConfig[difficulty][field] = config.default[field].concat(config.difficulties[difficulty][field] || []);
+      }
+    }
+  }
+
+  return newConfig;
+}
+
+
+// Replace all the names to ids and save them to the config.
+async function convertNamesToIds(config) {
+  for (const difficulty in config) {
+    for (const field in config[difficulty]) {
+      if (field === "items") {
+        for (const item of config[difficulty][field]) {
+          const newItem = await Item.findOne({ name: item });
+          if (newItem) {
+            config[difficulty][field].splice(config[difficulty][field].indexOf(item), 1, newItem.id);
+          }
+          else {
+            console.log(`Item ${item} not found.`);
+          }
+        }
+      }
+      else if (field === "completed" || field === "inprogress") {
+        for (const skill of config[difficulty][field]) {
+          const skillName = skill.split(" ")[0];
+          const skillLevel = skill.split(" ")[1];
+          const newSkill = await Skill.findOne({ title: skillName, level: skillLevel });
+          if (newSkill) {
+            config[difficulty][field].splice(config[difficulty][field].indexOf(skill), 1, newSkill.id);
+          }
+          else {
+            console.log(`Could not find skill ${skill}`);
+          }
+        }
+      }
+    }
+  }
+  return config;
+}
+
+// Print out the new config. (Debugging purposes)
+// eslint-disable-next-line no-unused-vars
+async function printConfig(config) {
+  console.log(config);
+}
+
+
+async function run() {
+  const config = await createConfig();
+  const configWithIds = await convertNamesToIds(config);
+  return configWithIds;
+}
+
+module.exports = run();


### PR DESCRIPTION
**What does this do and how?**
Simply, it changes the place where the skills and items given during setup are configured. The difficulties are written with plain English using the names of the items and skills, then with a simple script converted to IDs and into a proper format during startup. To then be sent to the user controller and used normally with the setup command.

**Why though?**
Because the hard-coded IDs only work on OUR database. If we were to, for example, reset our database, the new IDs given to the skills and items won't apply to the hard-coded ones. Also, someone self-hosting will have problems with IDs.