### PR TITLE
changed inconsistent isDevelopment usage

### DIFF
--- a/src/models/item.model.js
+++ b/src/models/item.model.js
@@ -28,6 +28,6 @@ const itemSchema = new Schema({
     required: true,
     unique: false
   },
-}, { collection: config.isDevelopment === "development" ? "ItemsDev" : "Items"});
+}, { collection: config.isDevelopment ? "ItemsDev" : "Items"});
 
 module.exports = mongoose.model("Item", itemSchema);


### PR DESCRIPTION
Checking for the development environment variable is different in itemsDev than in all others, causing it to always fall back to the Items collection no matter what.